### PR TITLE
fixed "Query parameter argument must be a QueryParameter object" exception

### DIFF
--- a/BaseSpace-tools/DownloadData.py
+++ b/BaseSpace-tools/DownloadData.py
@@ -23,7 +23,7 @@ def Main():
     myAPI = BaseSpaceAPI(client_key,client_secret,BaseSpaceUrl,"v1pre3","AA",token)
     user = myAPI.getUserById('current')
     print >> sys.stderr, "\nUser name: %s\n"%(str(user))
-    Projects = myAPI.getProjectByUser('current')
+    Projects = myAPI.getProjectByUser()
     Found = False
     for p in Projects:
         if p.Name == args.project:


### PR DESCRIPTION
as discussed here: https://github.com/basespace/basespace-python-sdk/issues/8
